### PR TITLE
feat: add commander to the library

### DIFF
--- a/bin/head-space.js
+++ b/bin/head-space.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("../dist/index")(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.7",
+        "commander": "^8.3.0",
         "tsconfigs": "^5.0.0"
       },
       "bin": {
@@ -1969,6 +1970,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/concat-map": {
@@ -7451,6 +7460,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
+    "dev": "tsc -w",
     "test": "jest"
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
   },
   "dependencies": {
     "@types/node": "^16.11.7",
+    "commander": "^8.3.0",
     "tsconfigs": "^5.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
-console.log("hello world");
+import { program } from "commander";
 
-asdflj={asdf};
+export = (args: string[]) => {
+  program
+    .command("run")
+    .description("Runs the program")
+    .action((run) => {
+      console.log("Running the program")
+    })
+
+  program.parse();
+}
+


### PR DESCRIPTION
This PR sets up commander with a basic run command.

Try it out:

checkout the `add-commander` branch
run: `nom run build` to compile Typescript
run: `./bin/head-space.js --help` and `./bin/head-space.js run` to see output

Resolves #2